### PR TITLE
bump lucid2 version

### DIFF
--- a/lucid2/ChangeLog.md
+++ b/lucid2/ChangeLog.md
@@ -17,3 +17,7 @@ Converted lucid1 version of lucid-htmx to lucid2 version
 ## 0.1.0.8
 
 Change name of package from lucid-htmx to lucid2-htmx to avoid name collision on hackage
+
+## 0.1.0.9
+
+Relax upper bound of `lucid2` dependency up to, and including, 0.0.20250303

--- a/lucid2/lucid2-htmx.cabal
+++ b/lucid2/lucid2-htmx.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           lucid2-htmx
-version:        0.1.0.8
+version:        0.1.0.9
 synopsis:       Use htmx in your lucid templates
 description:    Please see the README on GitHub at <https://github.com/monadicsystems/lucid-htmx/tree/main/lucid2#readme>
 category:       Web, HTML
@@ -34,7 +34,7 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , lucid2 <= 0.0.20220526
+    , lucid2 <= 0.0.20250303
     , text
   default-extensions:
     OverloadedStrings
@@ -54,7 +54,7 @@ test-suite lucid2-htmx-test
       base >=4.7 && <5
     , HUnit
     , hspec
-    , lucid2 <= 0.0.20220526
-    , lucid2-htmx <= 0.1.0.8
+    , lucid2 <= 0.0.20250303
+    , lucid2-htmx <= 0.1.0.9
     , text
   default-language: Haskell2010


### PR DESCRIPTION
Updating lucid2 version in the library and tests to allow building with ghc 9.6.7.